### PR TITLE
Add environment variable for Discord webhook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Example environment variables for pixel-portfolio
+# Copy this file to .env and fill in your own values
+
+# Discord webhook URL for contact form submissions
+REACT_APP_DISCORD_WEBHOOK=

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Pixel Portfolio
+
+A pixel-styled React portfolio site.
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Create a `.env` file based on `.env.example` and set your Discord webhook URL:
+
+```bash
+cp .env.example .env
+# Edit .env and set REACT_APP_DISCORD_WEBHOOK
+```
+
+3. Start the development server:
+
+```bash
+npm start
+```
+
+The app will run with hot reloading enabled.

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -5,7 +5,7 @@ const Contact = () => {
   const [status, setStatus] = useState("");
   const [cooldown, setCooldown] = useState(false);
 
-  const webhookURL = "https://discordapp.com/api/webhooks/1390405974086647891/JINyEWekHx8ZlUH2Jt4rAnEMcto8es2YHpEvj7dUU5FvbOv8jEV2AaS9eA9CZanzN-bZ";
+  const webhookURL = process.env.REACT_APP_DISCORD_WEBHOOK;
   const handleChange = (e) => {
     setFormData((prev) => ({ ...prev, [e.target.name]: e.target.value }));
   };


### PR DESCRIPTION
## Summary
- fetch Discord webhook URL from `REACT_APP_DISCORD_WEBHOOK`
- provide example `.env` file
- document setup steps for defining the environment variable

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866df6c91b0832c9478c79ba344122b