### PR TITLE
Add Markdown rendering for blog posts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^7.6.3",
-    "react-scripts": "^5.0.1"
+    "react-scripts": "^5.0.1",
+    "marked": "^9.0.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.14",

--- a/src/components/blog/BlogPost.jsx
+++ b/src/components/blog/BlogPost.jsx
@@ -1,4 +1,5 @@
 import { useParams } from "react-router-dom";
+import { marked } from "marked";
 import posts from "../../posts";
 
 export default function BlogPost() {
@@ -14,11 +15,10 @@ export default function BlogPost() {
       <div className="max-w-3xl mx-auto px-4">
       <h1 className="text-4xl font-bold mb-4">{post.title}</h1>
       <p className="text-sm text-purple-400 mb-8">{post.date}</p>
-      <article className="prose prose-invert prose-p:text-gray-200">
-        {post.content.split("\n").map((line, index) => (
-          <p key={index}>{line}</p>
-        ))}
-      </article>
+      <article
+        className="prose prose-invert prose-p:text-gray-200"
+        dangerouslySetInnerHTML={{ __html: marked.parse(post.content) }}
+      />
     </div>
     </div>
   );

--- a/src/posts.js
+++ b/src/posts.js
@@ -10,7 +10,7 @@ const posts = [
 Welcome, traveler. This post marks the beginning of my journey building a fantasy-themed developer portfolio...
 
 *Stay tuned, the incantations are just beginning.*
-    `
+`
   }
   // Add more posts...
 ];


### PR DESCRIPTION
## Summary
- add `marked` to dependencies
- render blog posts using markdown instead of splitting lines
- cleanup post content formatting

## Testing
- `npm run build` *(fails: Module not found: Can't resolve 'marked')*

------
https://chatgpt.com/codex/tasks/task_e_6866df721f78832cb012c52c5b3aac97